### PR TITLE
Issue 1: more contrasty text for web accessibility 508 compliance

### DIFF
--- a/landingpage.css
+++ b/landingpage.css
@@ -125,7 +125,7 @@ ol.inline:hover>li:last-child:after
 #dates dl:first-of-type dt:last-of-type,
 #dates dl:first-of-type dd ~ dd
 {
-	color: gray;
+	color: dimgray;
 }
 
 #dates dl:first-of-type dd:last-of-type {
@@ -136,7 +136,7 @@ ol.inline:hover>li:last-child:after
 }
 
 #dates dl:first-of-type dd + dt{
-	color: darkgray;
+	color: #444;
 }
 
 #contact.sidebyside dl dt {
@@ -178,7 +178,7 @@ ol.inline:hover>li:last-child:after
 }
 
 #metadata dl dd a {
-	text-decoration-color: gray;
+	text-decoration-color: dimgray;
 }
 
 #metadata dt,
@@ -205,7 +205,7 @@ ol.inline:hover>li:last-child:after
 }
 
 #metadata dd {
-	color: gray;
+	color: dimgray;
 }
 
 #metadata dt.browsable,


### PR DESCRIPTION
Replacing color values for text that failed ANDI 508 validation for contrast, gray/darkgray to dimgray/444 (even darker).

This has not yet been retested locally.
I can retest it with ANDI if deployed at http://dc.g-vo.org/LP/, or wait until I can do a local deploy.